### PR TITLE
fix: env var typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+*.swp
+*.DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,26 @@
 {
-    "name": "mcphub-gateway",
-    "version": "1.0.0",
+    "name": "@mcphub/gateway",
+    "version": "1.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "mcphub-gateway",
-            "version": "1.0.0",
+            "name": "@mcphub/gateway",
+            "version": "1.0.1",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.0.3",
                 "eventsource": "^2.0.2"
+            },
+            "bin": {
+                "mcphub-gateway": "dist/src/mcphub-gateway.js"
             },
             "devDependencies": {
                 "@types/eventsource": "^1.1.15",
                 "@types/node": "^20.11.0",
                 "typescript": "^5.3.3"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@modelcontextprotocol/sdk": {

--- a/src/mcphub-gateway.ts
+++ b/src/mcphub-gateway.ts
@@ -3,7 +3,7 @@
 import EventSource from "eventsource";
 
 // Configuration
-const MCP_SERVER_URL = process.env.MCPHUB_SERVER_URL || "https://server.mcphub.ai/api/mcp";
+const MCP_SERVER_URL = process.env.MCP_SERVER_URL || "https://server.mcphub.ai/api/mcp";
 
 const baseUrl = MCP_SERVER_URL;
 const backendUrlSse = `${baseUrl}/sse`;


### PR DESCRIPTION
The README.md instruction for environment value doesn't matched with code.

modified the variable as MCP_SERVER_URL (that instructed in md file)